### PR TITLE
Use `self` instead of strongSelf

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -774,16 +774,21 @@ Code should not create reference cycles. Analyze your object graph and prevent s
 
 ### Extending object lifetime
 
-Extend object lifetime using the `[weak self]` and `guard let strongSelf = self else { return }` idiom. `[weak self]` is preferred to `[unowned self]` where it is not immediately obvious that `self` outlives the closure. Explicitly extending lifetime is preferred to optional unwrapping.
+Extend object lifetime using the `[weak self]` and ``guard let `self` = self else { return }`` idiom. `[weak self]` is preferred to `[unowned self]` where it is not immediately obvious that `self` outlives the closure. Explicitly extending lifetime is preferred to optional unwrapping.
+
+A note about backtick syntax:
+> To use a reserved word as an identifier, put a backtick (\`) before and after it. For example, `class` is not a valid identifier, but `` `class` `` is valid. The backticks are not considered part of the identifier; `` `x` `` and `x` have the same meaning.
+
+See the full [Apple documentation](https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/LexicalStructure.html) for more details.
 
 **Preferred**
 ```swift
 resource.request().onComplete { [weak self] response in
-  guard let strongSelf = self else {
+  guard let `self` = self else {
     return
   }
-  let model = strongSelf.updateModel(response)
-  strongSelf.updateUI(model)
+  let model = self.updateModel(response)
+  self.updateUI(model)
 }
 ```
 


### PR DESCRIPTION
Updated references of `strongSelf` to use `` `self` ``, for improved development experience (DX?).

Using this syntax, the developer is able to add the [weak self]/guard idiom to a closure without changing existing code, as self will now reference the identifier defined in the guard statement.