### PR TITLE
Don't recommend static keyword preceding access control specifiers

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -816,7 +816,7 @@ Prefer `private` to `fileprivate` when possible. Using extensions may require yo
 
 Only explicitly use `open`, `public`, and `internal` when you require a full access control specification.
 
-Use access control as the leading property specifier. The only things that should come before access control are the `static` specifier or attributes such as `@IBAction`, `@IBOutlet` and `@discardableResult`.
+Use access control as the leading property specifier. The only things that should come before access control are attributes such as `@IBAction`, `@IBOutlet` and `@discardableResult`.
 
 **Preferred:**
 ```swift


### PR DESCRIPTION
Interested to hear if anyone feels strongly about this. I was just surprised to see this guidance and it seems off to me. The only rationale I can offer for removing it, though, is that if the general rule is that access control comes first, I don't see a compelling reason for the static keyword to be an exception. 